### PR TITLE
Update zh-Hant.arb and zh.arb

### DIFF
--- a/locale/zh-Hant.arb
+++ b/locale/zh-Hant.arb
@@ -91,7 +91,7 @@
     "installer_btn_reinstall": "重新安裝",
     "installer_btn_update": "更新",
     "installer_btn_downgrade": "降級（不安全）",
-    "installer_btn_dismiss": "解除",
+    "installer_btn_dismiss": "完成",
     "installer_btn_open": "開啟應用程式",
     "installer_btn_checkbox_shortcut": "建立桌面快捷方式",
 
@@ -104,7 +104,7 @@
     "android_permission_microphone": "麥克風",
     "android_permission_camera": "相機",
     "android_permission_location": "位置",
-    "android_permission_phone": "手機",
+    "android_permission_phone": "電話",
     "android_permission_call_log": "通訊記錄",
     "android_permission_sms": "訊息",
     "android_permission_contacts": "聯絡人",

--- a/locale/zh.arb
+++ b/locale/zh.arb
@@ -84,7 +84,7 @@
     "installer_btn_reinstall": "重新安装",
     "installer_btn_update": "更新",
     "installer_btn_downgrade": "降级（不安全）",
-    "installer_btn_dismiss": "解除",
+    "installer_btn_dismiss": "完成",
     "installer_btn_open": "打开应用程序",
     "installer_btn_checkbox_shortcut": "创建桌面快捷方式",
 


### PR DESCRIPTION

### Main Change

Button `installer_btn_dismiss` will be displayed at the bottom right corner when users successfully finish installing an APK:

![sample.png](https://www.gdaily.org/wp-content/uploads/2021/10/Snipaste_2022-05-03_16-52-18.png)

However, the word "解除" itself is a little bit confusing - it might be associated with "uninstall" or "remove".

Term "完成" seems to be a better candidate (suggested by the post: https://www.gdaily.org/28576/windows-11-install-apk-android-app). It is widely used by many installation wizards.


### Additional Change

Apply the patch introduced by  #75 for zh-Hant as well, which replaces "手機" with "電話" when referencing `android_permission_phone`.
