### PR TITLE
Fixed spelling of successfully when completing installation of .apk

### DIFF
--- a/locale/en.arb
+++ b/locale/en.arb
@@ -79,7 +79,7 @@
     "@installer_info_package" : {"placeholders": {"appPackage": {"type": "String"}}},
     "installer_installing": "Installing application {appTitle}...",
     "@installer_installing" : {"placeholders": {"appTitle": {"type": "String"}}},
-    "installer_installed": "The application {appTitle} was successifully installed",
+    "installer_installed": "The application {appTitle} was successfully installed",
     "@installer_installed" : {"placeholders": {"appTitle": {"type": "String"}}},
     "installer_fail": "The application {appTitle} was not installed",
     "@installer_fail" : {"placeholders": {"appTitle": {"type": "String"}}},


### PR DESCRIPTION
## Note when successfully installing a `.apk` I am greeted with this prompt with the incorrect spelling of `successfully`

Below is the result

![spelling error](https://user-images.githubusercontent.com/45560312/175523326-d90f8983-d5c7-42dd-a6ae-75ea4c55a445.png)

I have patched the above to correct the spelling `successfully`.
